### PR TITLE
WebSocketを送りすぎないようにしました

### DIFF
--- a/apiserver/apiserver.ts
+++ b/apiserver/apiserver.ts
@@ -227,7 +227,7 @@ export const match = async (req: ServerRequest) => {
   //console.log(req, "newPlayer");
   try {
     const reqData = (await req.json()) as IMatchRequest;
-    console.log(reqData);
+    //console.log(reqData);
 
     const identifier = reqData.id || reqData.name;
     if (!identifier) throw Error("Invalid id or name.");
@@ -507,7 +507,7 @@ const getGame = (id: string): any => {
     LogFileOp.getLogGames(),
   ];
   //console.log(games);
-  console.log("getGame!!", id);
+  //console.log("getGame!!", id);
   try {
     if (id) return games.flat().find((e) => (e.uuid || e.gameId) === id);
     else return games[0].reverse()[0];

--- a/apiserver/apiserver.ts
+++ b/apiserver/apiserver.ts
@@ -440,8 +440,11 @@ const ws_AllGame = async (sock: WebSocket) => {
   }
 };
 
-const sendAllGame = () => {
-  //console.log(socks.length);
+let sendAllGameQue = 0;
+
+setInterval(() => {
+  if (sendAllGameQue === 0) return;
+  sendAllGameQue = 0;
   const games = [
     kkmm.getGames(),
     kkmm_self.getGames(),
@@ -461,6 +464,10 @@ const sendAllGame = () => {
     }
     return false;
   });
+}, 1000);
+
+const sendAllGame = () => {
+  sendAllGameQue++;
 };
 
 let getGameSocks: { sock: WebSocket; id: string }[] = [];

--- a/apiserver/parts/expKakomimasu.js
+++ b/apiserver/parts/expKakomimasu.js
@@ -90,7 +90,7 @@ class ExpGame extends Game {
   }
 
   wsSend() {
-    console.log("expKakomimasu", this.uuid);
+    //console.log("expKakomimasu", this.uuid);
     this.changeFuncs.forEach((func) => func(this.uuid));
   }
 }


### PR DESCRIPTION
今までは各ゲームの状態更新時にソケットを送信していましたが、これだと100個のゲームインスタンスが同時に更新されたときに100回送ってしまい、回線がパンクしてしまうという状態になっていました。
したがって、最短でも1秒の間隔を空けて送信するように変更しました。