### PR TITLE
対AI戦をしたときにゲーム名を設定する

### DIFF
--- a/apiserver/match.ts
+++ b/apiserver/match.ts
@@ -112,6 +112,9 @@ export const matchRouter = () => {
         const brd = BoardFileOp.get(bname); //readBoard(bname);
         if (!reqData.option?.dryRun) {
           const game = kkmm.createGame(brd);
+          game.name =
+            `対AI戦：${user.screenName}(@${user.name}) vs AI(${ai.name})`;
+
           game.changeFuncs.push(sendAllGame);
           game.changeFuncs.push(sendGame);
           game.attachPlayer(player);


### PR DESCRIPTION
Fixes #147

下記画像のように「対AI戦："ユーザ表示名"(@”ユーザ名”) vs AI("AI名")」と表示されるようにしました。
![image](https://user-images.githubusercontent.com/47011206/113505390-7fa47d80-9579-11eb-9788-a94c93fb4bfc.png)
