### PR TITLE
ログゲームの扱いを変更&Kakomimasu.jsの型定義ファイルを作成

### DIFF
--- a/Kakomimasu.d.ts
+++ b/Kakomimasu.d.ts
@@ -1,0 +1,263 @@
+export class Board {
+  constructor(
+    w: number | object,
+    h?: number,
+    points?: number[],
+    nagent?: number,
+    nturn?: number,
+    nsec?: number,
+    nplayer?: number,
+  );
+
+  static restore(data: any): Board;
+
+  toLogJSON(): object;
+  getJSON(): {
+    name: string;
+    w: number;
+    h: number;
+    points: number[];
+    nagents: number;
+    nturn: number;
+    nsec: number;
+    nplayer: number;
+  };
+
+  toJSON(): {
+    name: string;
+    width: number;
+    height: number;
+    nAgent: number;
+    nPlayer: number;
+    nTurn: number;
+    nSec: number;
+    points: number[];
+  };
+}
+
+type AgentGetJSON = { x: number; y: number };
+
+export class Agent {
+  public board: Board;
+  public field: Field;
+  public playerid: number;
+  public x: number;
+  public y: number;
+  public bkx: number;
+  public bky: number;
+  public lastaction: Action;
+  constructor(board: Board, field: Field, playerid: number);
+
+  static restore(data: any, board: Board, field: Field): Agent;
+
+  toLogJSON(): any;
+
+  isOnBoard(): boolean;
+
+  // AgentがBoard上に乗っているいるかの確認
+  checkOnBoard(x: number, y: number): boolean;
+
+  // Agentの移動先が上下左右1マスかの確認
+  checkDir(x: number, y: number): boolean;
+
+  // AgentがPutできるかの確認
+  checkPut(x: number, y: number): boolean;
+
+  // AgentがNoneできるかの確認
+  checkNone(x: number, y: number): boolean;
+
+  // AgentがMoveできるかの確認
+  checkMove(x: number, y: number): boolean;
+
+  // AgentがRemoveできるかの確認
+  checkRemove(x: number, y: number): boolean;
+
+  // lastactionが成功したかの確認
+  isValidAction(): boolean;
+
+  putOrMove(): boolean;
+
+  put(x: number, y: number): boolean;
+
+  none(x: number, y: number): boolean;
+  move(x: number, y: number): boolean;
+  remove(): boolean;
+
+  commit(): void;
+  revert(): void;
+
+  getJSON(): { x: number; y: number };
+
+  check(act: Action): boolean;
+}
+
+type ActionType = 1 | 2 | 3 | 4;
+type ActionRes = 0 | 1 | 2 | 3 | 4 | 5;
+
+export class Action {
+  public agentid: number;
+  public type: ActionType;
+  public x: number;
+  public y: number;
+  public res: ActionRes;
+
+  // Action Type
+  public static readonly PUT = 1;
+  public static readonly NONE = 2;
+  public static readonly MOVE = 3;
+  public static readonly REMOVE = 4;
+
+  // Action Res
+  public static readonly SUCCESS = 0;
+  public static readonly CONFLICT = 1;
+  public static readonly REVERT = 2;
+  public static readonly ERR_ONLY_ONE_TURN = 3;
+  public static readonly ERR_ILLEGAL_AGENT = 4;
+  public static readonly ERR_ILLEGAL_ACTION = 5;
+
+  constructor(agentid: number, type: ActionType, x: number, y: number);
+
+  getJSON(): {
+    agentId: number;
+    type: ActionType;
+    x: number;
+    y: number;
+    res: ActionRes;
+  };
+
+  static getMessage(res: ActionRes): string;
+  static fromJSON(array: [number, ActionType, number, number][]): Action[];
+}
+
+type FieldType = 0 | 1;
+type FieldCell = [FieldType, number];
+
+export class Field {
+  public board: Board;
+  public field: FieldCell[];
+
+  public static readonly BASE = 0;
+  public static readonly WALL = 1;
+
+  constructor(board: Board);
+
+  toLogJSON(): any;
+
+  set(x: number, y: number, att: FieldType, playerid: number): void;
+  get(x: number, y: number): FieldCell;
+  setAgent(playerid: number, x: number, y: number): boolean;
+  fillBase(): void;
+  getPoints(): { basepoint: number; wallpoint: number }[];
+  getJSON(): FieldCell[];
+}
+
+export class Game {
+  public uuid: string;
+  public board: Board;
+  public players: Player[];
+  public nturn: number;
+  public nsec: number;
+  public gaming: boolean;
+  public ending: boolean;
+  public field: Field;
+  public log: {
+    point: number;
+    actions: ReturnType<typeof Agent.prototype.getJSON>[];
+  }[];
+  public turn: number;
+  public agents: Agent[][];
+
+  constructor(board: Board);
+
+  static restore(data: any): Game;
+
+  toLogJSON(): any;
+  attachPlayer(player: Player): boolean;
+  isReady(): boolean;
+  isFree(): boolean;
+  isGaming(): boolean;
+
+  start(): void;
+  nextTurn(): boolean;
+  checkActions(): void;
+  checkConflict(): void;
+  checkAgentConflict(): void;
+  putOrMove(): void;
+  revertOverlap(): void;
+  removeOrNot(): void;
+  revertNotOwnerWall(): void;
+  commit(): void;
+  getStatusJSON(): {
+    players: ReturnType<typeof Player.prototype.getJSON>[];
+    board: ReturnType<typeof Board.prototype.getJSON>;
+    field: ReturnType<typeof Field.prototype.getJSON>;
+    agents: ReturnType<typeof Agent.prototype.getJSON>[][];
+    points: ReturnType<typeof Field.prototype.getPoints>;
+    log: typeof Game.prototype.log;
+  };
+
+  toJSON(): {
+    gameId: typeof Game.prototype.uuid; //string;
+    gaming: typeof Game.prototype.gaming; // boolean;
+    ending: typeof Game.prototype.ending; //boolean;
+    board: ReturnType<Board["toJSON"]> | null;
+    turn: typeof Game.prototype.turn;
+    totalTurn: typeof Game.prototype.nturn;
+    tiled: typeof Game.prototype.field.field | null;
+    players: {
+      id: number;
+      agents: Agent[];
+      point: ReturnType<typeof Field.prototype.getPoints>[0];
+    }[];
+    log: typeof Game.prototype.log;
+  };
+}
+
+export class Player {
+  public accessToken: string;
+  public id: string;
+  public spec: string;
+  public game: Game | null;
+  public actions: Action[];
+  public index: number;
+
+  constructor(id: string, spec: string);
+
+  static restore(data: any): Player;
+
+  toLogJSON(): any;
+
+  setGame(game: Game): void;
+  noticeStart(): void;
+  setActions(actions: Action[]): typeof Game.prototype.turn;
+  getActions(): typeof Player.prototype.actions;
+  clearActions(): void;
+  getJSON(): {
+    userId: typeof Player.prototype.id;
+    spec: typeof Player.prototype.spec;
+    accessToken: typeof Player.prototype.accessToken;
+    gameId: null | typeof Game.prototype.uuid;
+    index: typeof Player.prototype.index;
+  };
+}
+
+type AbstractConstructorHelper<T> = (new (...args: any) => {}) & T;
+type AbstractContructorParameters<T> = ConstructorParameters<
+  AbstractConstructorHelper<T>
+>;
+
+export abstract class Kakomimasu<T extends Game = Game> {
+  public games: T[];
+  public boards: Board[];
+
+  constructor();
+
+  appendBoard(board: Board): void;
+  getBoards(): typeof Kakomimasu.prototype.boards;
+  abstract createGame(
+    ...param: ConstructorParameters<(new (...args: any) => {}) & T>
+  ): T;
+  getGames(): typeof Kakomimasu.prototype.games;
+  getFreeGames(): T[];
+  createPlayer(playername: string, spec?: string): Player;
+}

--- a/apiserver/apiserver.ts
+++ b/apiserver/apiserver.ts
@@ -29,18 +29,14 @@ import { matchRouter } from "./match.ts";
 
 export const kkmm = new ExpKakomimasu();
 kkmm.games.push(...LogFileOp.read());
-export const kkmm_self = new ExpKakomimasu();
-//#region WebSocket
 
+//#region WebSocket
 let socks: WebSocket[] = [];
 
 const ws_AllGame = async (sock: WebSocket) => {
   try {
     await sock.send(
-      JSON.stringify([
-        kkmm.getGames(),
-        kkmm_self.getGames(),
-      ]),
+      JSON.stringify(kkmm.getGames()),
     );
     socks.push(sock);
 
@@ -64,10 +60,7 @@ let sendAllGameQue = 0;
 setInterval(() => {
   if (sendAllGameQue === 0) return;
   sendAllGameQue = 0;
-  const games = [
-    kkmm.getGames(),
-    kkmm_self.getGames(),
-  ];
+  const games = kkmm.getGames();
 
   socks = socks.filter((s) => {
     try {
@@ -130,10 +123,7 @@ export const sendGame = (id: string) => {
 };
 
 const getGame = (id: string): any => {
-  const games = [
-    kkmm.getGames(),
-    kkmm_self.getGames(),
-  ];
+  const games = kkmm.getGames();
   //console.log(games);
   //console.log("getGame!!", id);
   try {

--- a/apiserver/apiserver.ts
+++ b/apiserver/apiserver.ts
@@ -5,7 +5,7 @@ import {
   createRouter,
   ServerRequest,
   serveStatic,
-} from "https://servestjs.org/@v1.1.9/mod.ts";
+} from "https://deno.land/x/servest@v1.2.0/mod.ts";
 
 import * as util from "./apiserver_util.ts";
 const resolve = util.pathResolver(import.meta);

--- a/apiserver/apiserver.ts
+++ b/apiserver/apiserver.ts
@@ -13,9 +13,6 @@ const resolve = util.pathResolver(import.meta);
 import { Board } from "../Kakomimasu.js";
 import { ExpKakomimasu } from "./parts/expKakomimasu.js";
 
-export const kkmm = new ExpKakomimasu();
-export const kkmm_self = new ExpKakomimasu();
-
 import { config } from "https://deno.land/x/dotenv@v2.0.0/mod.ts";
 const env = config({
   path: resolve("./.env"),
@@ -30,6 +27,9 @@ import { userRouter } from "./user.ts";
 import { gameRouter } from "./game.ts";
 import { matchRouter } from "./match.ts";
 
+export const kkmm = new ExpKakomimasu();
+kkmm.games.push(...LogFileOp.read());
+export const kkmm_self = new ExpKakomimasu();
 //#region WebSocket
 
 let socks: WebSocket[] = [];
@@ -40,7 +40,6 @@ const ws_AllGame = async (sock: WebSocket) => {
       JSON.stringify([
         kkmm.getGames(),
         kkmm_self.getGames(),
-        LogFileOp.getLogGames(),
       ]),
     );
     socks.push(sock);
@@ -68,7 +67,6 @@ setInterval(() => {
   const games = [
     kkmm.getGames(),
     kkmm_self.getGames(),
-    LogFileOp.getLogGames(),
   ];
 
   socks = socks.filter((s) => {
@@ -135,7 +133,6 @@ const getGame = (id: string): any => {
   const games = [
     kkmm.getGames(),
     kkmm_self.getGames(),
-    LogFileOp.getLogGames(),
   ];
   //console.log(games);
   //console.log("getGame!!", id);

--- a/apiserver/apiserver.ts
+++ b/apiserver/apiserver.ts
@@ -11,7 +11,7 @@ import * as util from "./apiserver_util.ts";
 const resolve = util.pathResolver(import.meta);
 
 import { Board } from "../Kakomimasu.js";
-import { ExpKakomimasu } from "./parts/expKakomimasu.js";
+import { ExpKakomimasu } from "./parts/expKakomimasu.ts";
 
 import { config } from "https://deno.land/x/dotenv@v2.0.0/mod.ts";
 const env = config({

--- a/apiserver/game.ts
+++ b/apiserver/game.ts
@@ -11,7 +11,7 @@ import { kkmm, sendAllGame, sendGame } from "./apiserver.ts";
 import { tournaments } from "./tournament.ts";
 import { BoardFileOp } from "./parts/file_opration.ts";
 
-import { ExpGame } from "./parts/expKakomimasu.js";
+import { ExpGame } from "./parts/expKakomimasu.ts";
 
 interface ICreateGameReq extends ApiOption {
   name?: string;
@@ -51,6 +51,7 @@ export const gameRouter = () => {
             const userIds = reqJson.playerIdentifiers.map((e) => {
               const id = accounts.find(e)?.id;
               if (!id) throw new ServerError(errors.NOT_USER);
+              return id;
             });
             userIds.forEach((userId) => {
               if (!game.addReservedUser(userId)) {

--- a/apiserver/game.ts
+++ b/apiserver/game.ts
@@ -1,7 +1,7 @@
 import {
   contentTypeFilter,
   createRouter,
-} from "https://servestjs.org/@v1.1.9/mod.ts";
+} from "https://deno.land/x/servest@v1.2.0/mod.ts";
 
 import { jsonResponse } from "./apiserver_util.ts";
 import { accounts } from "./user.ts";

--- a/apiserver/game.ts
+++ b/apiserver/game.ts
@@ -3,16 +3,11 @@ import {
   createRouter,
 } from "https://servestjs.org/@v1.1.9/mod.ts";
 
-import {
-  errorResponse,
-  jsonResponse,
-  readJsonFileSync,
-} from "./apiserver_util.ts";
-import util from "../util.js";
+import { jsonResponse } from "./apiserver_util.ts";
 import { accounts } from "./user.ts";
 import { ApiOption } from "./parts/interface.ts";
 import { errorCodeResponse, errors, ServerError } from "./error.ts";
-import { kkmm_self, readBoard, sendAllGame, sendGame } from "./apiserver.ts";
+import { kkmm, sendAllGame, sendGame } from "./apiserver.ts";
 import { tournaments } from "./tournament.ts";
 import { BoardFileOp } from "./parts/file_opration.ts";
 
@@ -43,7 +38,8 @@ export const gameRouter = () => {
 
         let game: ExpGame;
         if (!reqJson.option?.dryRun) {
-          game = kkmm_self.createGame(board, reqJson.name);
+          game = kkmm.createGame(board, reqJson.name);
+          game.type = "self";
 
           game.changeFuncs.push(sendAllGame);
           game.changeFuncs.push(sendGame);

--- a/apiserver/match.ts
+++ b/apiserver/match.ts
@@ -157,12 +157,10 @@ export const matchRouter = () => {
   });
   router.get(new RegExp("^/(.+)$"), async (req) => {
     try {
-      //console.log(LogFileOp.getLogGames());
       const id = req.match[1];
       const game = [
         ...kkmm.getGames(),
         ...kkmm_self.getGames(),
-        ...LogFileOp.getLogGames(),
       ]
         .find((item) => (item.uuid === id) || (item.gameId === id));
       if (!game) throw new ServerError(errors.NOT_GAME);

--- a/apiserver/match.ts
+++ b/apiserver/match.ts
@@ -1,7 +1,7 @@
 import {
   contentTypeFilter,
   createRouter,
-} from "https://servestjs.org/@v1.1.9/mod.ts";
+} from "https://deno.land/x/servest@v1.2.0/mod.ts";
 
 import { jsonResponse, pathResolver } from "./apiserver_util.ts";
 

--- a/apiserver/match.ts
+++ b/apiserver/match.ts
@@ -11,7 +11,7 @@ import util from "../util.js";
 import { accounts } from "./user.ts";
 import { ApiOption } from "./parts/interface.ts";
 import { errorCodeResponse, errors, ServerError } from "./error.ts";
-import { kkmm, kkmm_self, sendAllGame, sendGame } from "./apiserver.ts";
+import { kkmm, sendAllGame, sendGame } from "./apiserver.ts";
 import { aiList } from "./parts/ai-list.ts";
 import { Action } from "../Kakomimasu.js";
 
@@ -21,7 +21,7 @@ const env = config({
   defaults: resolve("./.env.default"),
 });
 const boardname = env.boardname; // || "E-1"; // "F-1" "A-1"
-import { BoardFileOp, LogFileOp } from "./parts/file_opration.ts";
+import { BoardFileOp } from "./parts/file_opration.ts";
 
 const getRandomBoardName = async () => {
   const bd = Deno.readDir(resolve("./board"));
@@ -92,7 +92,7 @@ export const matchRouter = () => {
 
       const player = kkmm.createPlayer(user.id, reqData.spec);
       if (reqData.gameId) {
-        const game = [...kkmm_self.getGames(), ...kkmm.getGames()].find((
+        const game = kkmm.getGames().find((
           game,
         ) => game.uuid === reqData.gameId);
         if (!game) throw new ServerError(errors.NOT_GAME);
@@ -158,11 +158,9 @@ export const matchRouter = () => {
   router.get(new RegExp("^/(.+)$"), async (req) => {
     try {
       const id = req.match[1];
-      const game = [
-        ...kkmm.getGames(),
-        ...kkmm_self.getGames(),
-      ]
-        .find((item) => (item.uuid === id) || (item.gameId === id));
+      const game = kkmm.getGames().find((item) =>
+        (item.uuid === id) || (item.gameId === id)
+      );
       if (!game) throw new ServerError(errors.NOT_GAME);
       await req.respond(jsonResponse(game));
     } catch (e) {
@@ -179,9 +177,7 @@ export const matchRouter = () => {
       const gameId = req.match[1];
       const accessToken = req.headers.get("Authorization");
 
-      const game = [...kkmm.getGames(), ...kkmm_self.getGames()].find((
-        item: any,
-      ) => item.uuid === gameId);
+      const game = kkmm.getGames().find((item: any) => item.uuid === gameId);
       if (!game) throw new ServerError(errors.NOT_GAME);
       const player = game.players.find((p: any) =>
         p.accessToken === accessToken

--- a/apiserver/parts/expKakomimasu.js
+++ b/apiserver/parts/expKakomimasu.js
@@ -82,8 +82,7 @@ export class ExpGame extends Game {
       }
     }
     else if (this.ending) { // ゲーム終了後
-      const data = this.toLogJSON();
-      LogFileOp.save(data);
+      LogFileOp.save(this);
 
       console.log("turn", this.turn);
       this.wsSend();

--- a/apiserver/parts/expKakomimasu.js
+++ b/apiserver/parts/expKakomimasu.js
@@ -12,6 +12,7 @@ export class ExpGame extends Game {
     this.nextTurnUnixTime = null;
     this.changeFuncs = [];
     this.reservedUsers = [];
+    this.type = "normal";
   }
 
   static restore(data) {
@@ -31,6 +32,7 @@ export class ExpGame extends Game {
     game.startedAtUnixTime = data.startedAtUnixTime;
     game.nextTurnUnixTime = data.nextTurnUnixTime;
     game.reservedUsers = data.reservedUsers;
+    game.type = data.type || "normal";
     return game;
   }
 
@@ -107,6 +109,7 @@ export class ExpGame extends Game {
       startedAtUnixTime: this.startedAtUnixTime,
       nextTurnUnixTime: this.nextTurnUnixTime,
       reservedUsers: this.reservedUsers,
+      type: this.type,
     };
   }
 
@@ -127,6 +130,11 @@ class ExpKakomimasu extends Kakomimasu {
     const game = new ExpGame(...param);
     this.games.push(game);
     return game;
+  }
+
+  getFreeGames() {
+    const games = super.getFreeGames();
+    return games.filter(game => game.type === "normal");
   }
 }
 

--- a/apiserver/parts/expKakomimasu.ts
+++ b/apiserver/parts/expKakomimasu.ts
@@ -1,12 +1,21 @@
 import util from "../../util.js";
-import { Game, Kakomimasu, Player, Agent, Board } from "../../Kakomimasu.js";
+
+// @deno-types="../../Kakomimasu.d.ts"
+import { Agent, Board, Game, Kakomimasu, Player } from "../../Kakomimasu.js";
 import { LogFileOp } from "./file_opration.ts";
 
 import { accounts } from "../user.ts";
 
 export class ExpGame extends Game {
-  constructor(board, name, dummy) {
-    super(board, dummy);
+  public name?: string;
+  public startedAtUnixTime: number | null;
+  public nextTurnUnixTime: number | null;
+  public changeFuncs: (((param?: any) => void))[];
+  public reservedUsers: string[];
+  public type: "normal" | "self";
+
+  constructor(board: Board, name?: string) {
+    super(board);
     this.name = name;
     this.startedAtUnixTime = null;
     this.nextTurnUnixTime = null;
@@ -15,18 +24,20 @@ export class ExpGame extends Game {
     this.type = "normal";
   }
 
-  static restore(data) {
+  static restore(data: any) {
     const board = Board.restore(data.board);
     const game = new ExpGame(board, data.name);
     game.uuid = data.uuid;
-    game.players = data.players.map(p => Player.restore(p));
+    game.players = (data.players as Array<any>).map((p) => Player.restore(p));
     game.gaming = data.gaming;
     game.ending = data.ending;
     game.field.field = data.field.field;
     game.log = data.log;
     game.turn = data.turn;
-    game.agents = data.players.map((p, i) => {
-      return data.agents[i].map(a => Agent.restore(a, game.board, game.field));
+    game.agents = (data.players as Array<any>).map((p, i) => {
+      return (data.agents[i] as Array<any>).map((a) =>
+        Agent.restore(a, game.board, game.field)
+      );
     });
 
     game.startedAtUnixTime = data.startedAtUnixTime;
@@ -36,8 +47,8 @@ export class ExpGame extends Game {
     return game;
   }
 
-  attachPlayer(player) {
-    if (this.reservedUsers > 0) {
+  attachPlayer(player: Player) {
+    if (this.reservedUsers.length > 0) {
       const isReservedUser = this.reservedUsers.some((e) => e === player.id);
       if (!isReservedUser) throw Error("Not allowed user");
     }
@@ -63,7 +74,7 @@ export class ExpGame extends Game {
     return ret;
   }
 
-  addReservedUser(userId) {
+  addReservedUser(userId: string) {
     if (this.reservedUsers.some((e) => e === userId)) {
       return false;
     } else {
@@ -72,8 +83,9 @@ export class ExpGame extends Game {
     }
   }
 
-  updateStatus() {
+  updateStatus = () => {
     if (this.isGaming()) { // ゲーム進行中
+      if (!this.nextTurnUnixTime) throw Error("nextTurnUnixTime is null");
       const diff = (this.nextTurnUnixTime * 1000) - new Date().getTime();
       if (diff <= 0) {
         this.nextTurn();
@@ -82,14 +94,14 @@ export class ExpGame extends Game {
       } else {
         setTimeout(() => this.updateStatus(), diff);
       }
-    }
-    else if (this.ending) { // ゲーム終了後
+    } else if (this.ending) { // ゲーム終了後
       LogFileOp.save(this);
 
       console.log("turn", this.turn);
       this.wsSend();
     } // ゲーム開始前
     else {
+      if (!this.startedAtUnixTime) throw Error("startedAtUnixTime is null");
       const diff = (this.startedAtUnixTime * 1000) - new Date().getTime();
       if (diff <= 0) {
         this.start();
@@ -99,7 +111,7 @@ export class ExpGame extends Game {
         setTimeout(() => this.updateStatus(), diff);
       }
     }
-  }
+  };
 
   toJSON() {
     const ret = super.toJSON();
@@ -125,8 +137,8 @@ export class ExpGame extends Game {
   }
 }
 
-class ExpKakomimasu extends Kakomimasu {
-  createGame(...param) {
+class ExpKakomimasu extends Kakomimasu<ExpGame> {
+  createGame(...param: ConstructorParameters<typeof ExpGame>) {
     const game = new ExpGame(...param);
     this.games.push(game);
     return game;
@@ -134,7 +146,7 @@ class ExpKakomimasu extends Kakomimasu {
 
   getFreeGames() {
     const games = super.getFreeGames();
-    return games.filter(game => game.type === "normal");
+    return games.filter((game) => game.type === "normal");
   }
 }
 

--- a/apiserver/parts/expKakomimasu.ts
+++ b/apiserver/parts/expKakomimasu.ts
@@ -84,32 +84,35 @@ export class ExpGame extends Game {
   }
 
   updateStatus = () => {
-    if (this.isGaming()) { // ゲーム進行中
-      if (!this.nextTurnUnixTime) throw Error("nextTurnUnixTime is null");
-      const diff = (this.nextTurnUnixTime * 1000) - new Date().getTime();
-      if (diff <= 0) {
-        this.nextTurn();
-        this.wsSend();
-        this.updateStatus();
-      } else {
-        setTimeout(() => this.updateStatus(), diff);
-      }
-    } else if (this.ending) { // ゲーム終了後
-      LogFileOp.save(this);
+    try {
+      if (this.isGaming()) { // ゲーム進行中
+        if (!this.nextTurnUnixTime) throw Error("nextTurnUnixTime is null");
+        const diff = (this.nextTurnUnixTime * 1000) - new Date().getTime();
+        if (diff <= 0) {
+          this.nextTurn();
+          this.wsSend();
+          this.updateStatus();
+        } else {
+          setTimeout(() => this.updateStatus(), diff);
+        }
+      } else if (this.ending) { // ゲーム終了後
+        LogFileOp.save(this);
 
-      console.log("turn", this.turn);
-      this.wsSend();
-    } // ゲーム開始前
-    else {
-      if (!this.startedAtUnixTime) throw Error("startedAtUnixTime is null");
-      const diff = (this.startedAtUnixTime * 1000) - new Date().getTime();
-      if (diff <= 0) {
-        this.start();
+        console.log("turn", this.turn);
         this.wsSend();
-        this.updateStatus();
-      } else {
-        setTimeout(() => this.updateStatus(), diff);
+      } // ゲーム開始前
+      else {
+        if (!this.startedAtUnixTime) throw Error("startedAtUnixTime is null");
+        const diff = (this.startedAtUnixTime * 1000) - new Date().getTime();
+        if (diff <= 0) {
+          this.start();
+          this.wsSend();
+          this.updateStatus();
+        } else {
+          setTimeout(() => this.updateStatus(), diff);
+        }
       }
+    } catch (e) {
     }
   };
 

--- a/apiserver/parts/file_opration.ts
+++ b/apiserver/parts/file_opration.ts
@@ -63,17 +63,13 @@ export class TournamentFileOp {
 
 export class LogFileOp {
   private static dir = resolve("../log");
-  private static logGames: any[] = [];
-  private static mtime: Date | null = null;
 
   static staticConstructor = (() => {
     Deno.mkdirSync(LogFileOp.dir, { recursive: true });
-    window.addEventListener("load", () => {
-      LogFileOp.getLogGames;
-    });
   })();
 
-  public static save(data: any) {
+  public static save(game: ExpGame) {
+    const data = game.toLogJSON();
     writeJsonFileSync(
       `${this.dir}/${data.startedAtUnixTime}_${data.uuid}.log`,
       data,
@@ -87,24 +83,6 @@ export class LogFileOp {
       games.push(ExpGame.restore(data));
     }
     return games;
-  }
-
-  public static getLogGames() {
-    const stat = Deno.statSync(this.dir);
-    if (stat.isDirectory) {
-      if (this.mtime?.getTime() !== stat.mtime?.getTime()) {
-        this.logGames.length = 0;
-        for (const dirEntry of Deno.readDirSync(this.dir)) {
-          const json = readJsonFileSync(`${this.dir}/${dirEntry.name}`);
-          this.logGames.push(ExpGame.restore(json));
-        }
-        this.mtime = stat.mtime;
-        //console.log("logGames Reflesh!");
-      } else {
-        //console.log("logGames no change");
-      }
-    }
-    return this.logGames;
   }
 }
 

--- a/apiserver/parts/file_opration.ts
+++ b/apiserver/parts/file_opration.ts
@@ -5,7 +5,7 @@ import { pathResolver } from "../apiserver_util.ts";
 import { IBoard } from "./interface.ts";
 import { IUser } from "../user.ts";
 import { ITournament, Tournament } from "../tournament.ts";
-import { ExpGame } from "./expKakomimasu.js";
+import { ExpGame } from "./expKakomimasu.ts";
 
 const resolve = pathResolver(import.meta);
 

--- a/apiserver/test/sample/afterAction_sample.json
+++ b/apiserver/test/sample/afterAction_sample.json
@@ -1,5 +1,5 @@
 {
-  "gameId": "54133d2d-66c0-47be-a37c-05164a09d89b",
+  "gameId": "0d6243ab-96cd-41a8-9c48-35ac947703b0",
   "gaming": true,
   "ending": false,
   "board": {
@@ -519,7 +519,7 @@
   ],
   "players": [
     {
-      "id": "8a78a84b-ac70-45b0-8916-cd940526725d",
+      "id": "ad868b26-2eea-4c6f-873a-b3693c9d0c66",
       "agents": [
         {
           "x": 1,
@@ -562,7 +562,7 @@
       "areaPoint": null
     },
     {
-      "id": "8a78a84b-ac70-45b0-8916-cd940526725d",
+      "id": "ad868b26-2eea-4c6f-873a-b3693c9d0c66",
       "agents": [
         {
           "x": -1,
@@ -632,7 +632,8 @@
     ]
   ],
   "gameName": "test",
-  "startedAtUnixTime": 1614703193,
-  "nextTurnUnixTime": 1614703195,
-  "reservedUsers": []
+  "startedAtUnixTime": 1618319170,
+  "nextTurnUnixTime": 1618319172,
+  "reservedUsers": [],
+  "type": "self"
 }

--- a/apiserver/test/sample/createGame_sample.json
+++ b/apiserver/test/sample/createGame_sample.json
@@ -1,5 +1,5 @@
 {
-  "gameId": "38a6aac7-96d5-4b2f-8e7b-b1d7124cc428",
+  "gameId": "0d6243ab-96cd-41a8-9c48-35ac947703b0",
   "gaming": false,
   "ending": false,
   "board": null,
@@ -11,5 +11,6 @@
   "gameName": "test",
   "startedAtUnixTime": null,
   "nextTurnUnixTime": null,
-  "reservedUsers": []
+  "reservedUsers": [],
+  "type": "self"
 }

--- a/apiserver/test/sample/matchGameInfo_sample.json
+++ b/apiserver/test/sample/matchGameInfo_sample.json
@@ -1,5 +1,5 @@
 {
-  "gameId": "54133d2d-66c0-47be-a37c-05164a09d89b",
+  "gameId": "0d6243ab-96cd-41a8-9c48-35ac947703b0",
   "gaming": false,
   "ending": false,
   "board": {
@@ -519,7 +519,7 @@
   ],
   "players": [
     {
-      "id": "8a78a84b-ac70-45b0-8916-cd940526725d",
+      "id": "ad868b26-2eea-4c6f-873a-b3693c9d0c66",
       "agents": [
         {
           "x": -1,
@@ -562,7 +562,7 @@
       "areaPoint": null
     },
     {
-      "id": "8a78a84b-ac70-45b0-8916-cd940526725d",
+      "id": "ad868b26-2eea-4c6f-873a-b3693c9d0c66",
       "agents": [
         {
           "x": -1,
@@ -607,7 +607,8 @@
   ],
   "log": [],
   "gameName": "test",
-  "startedAtUnixTime": 1614703193,
-  "nextTurnUnixTime": 1614703194,
-  "reservedUsers": []
+  "startedAtUnixTime": 1618319170,
+  "nextTurnUnixTime": 1618319171,
+  "reservedUsers": [],
+  "type": "self"
 }

--- a/apiserver/tournament.ts
+++ b/apiserver/tournament.ts
@@ -1,4 +1,4 @@
-import { createRouter } from "https://servestjs.org/@v1.1.9/mod.ts";
+import { createRouter } from "https://deno.land/x/servest@v1.2.0/mod.ts";
 
 import { errorResponse, jsonResponse } from "./apiserver_util.ts";
 import util from "../util.js";

--- a/apiserver/user.ts
+++ b/apiserver/user.ts
@@ -1,7 +1,7 @@
 import {
   contentTypeFilter,
   createRouter,
-} from "https://servestjs.org/@v1.1.9/mod.ts";
+} from "https://deno.land/x/servest@v1.2.0/mod.ts";
 
 import util from "../util.js";
 import { jsonResponse } from "./apiserver_util.ts";

--- a/public/gamelist.html
+++ b/public/gamelist.html
@@ -20,9 +20,8 @@
             <h1 id="title">ゲーム一覧</h1>
             <h4 id="now-time" v-cloak>現在時刻：{{nowTime}}</h4>
             <div class="game-table">
-                <button v-on:click="nowType = 0" :disabled="nowType === 0">ランダムマッチ</button>
-                <button v-on:click="nowType = 1" :disabled="nowType === 1">フリーマッチ</button>
-                <button v-on:click="nowType = 2" :disabled="nowType === 2">終了したゲーム</button>
+                <button v-on:click="nowType = 0" :disabled="nowType === 0">フリーマッチ</button>
+                <button v-on:click="nowType = 1" :disabled="nowType === 1">カスタムマッチ</button>
 
                 <games-list v-bind:games="games[nowType]"> </games-list>
             </div>
@@ -36,7 +35,7 @@
             const gameTableVue = new Vue({
                 el: ".game-table",
                 data: {
-                    games: [[], [], []],
+                    games: [[], []],
                     nowType: 0,
                 },
                 components: {
@@ -49,7 +48,7 @@
 
                 },
                 created: function () {
-                    this.nowType = 2;
+                    this.nowType = 0;
                 }
             });
 

--- a/public/gamelist.html
+++ b/public/gamelist.html
@@ -43,7 +43,8 @@
                 },
                 methods: {
                     update: async function (games) {
-                        this.games = games;
+                        console.log(games);
+                        this.games = [games.filter(game => game.type === "normal"), games.filter(game => game.type === "self")];
                     },
 
                 },

--- a/public/index.html
+++ b/public/index.html
@@ -61,7 +61,7 @@
           <a href="gamelist.html">ゲーム一覧はこちらから</a><br>
           <a href="gamedetails.html">最新のゲームビューアはこちらから</a><br>
           <a href="/vr/latest.html">最新のゲームビューア(VR版)はこちらから</a><br>
-          <a href="game/create.html">フリーゲーム作成はこちらから</a>
+          <a href="game/create.html">カスタムゲーム作成はこちらから</a>
         </div>
         <h3>大会</h3>
         <div>


### PR DESCRIPTION
1. ログゲームを再度インスタンス化できたことにより、扱いを以下のように変更しました。

- ランダムマッチ　→　フリーマッチ
- フリーマッチ　→　カスタムマッチ
- 終了したゲーム　→　廃止（フリー・カスタムマッチに統合）

2. Kakomimasu.jsの型定義ファイルを作成しました。
Denoでは以下のようにしてKakomimasu.jsをTypescriptでインポートできます。

```Typescript
// @deno-types="./Kakomimasu.d.ts"
import { Agent, Board, Game, Kakomimasu, Player } from "./Kakomimasu.js";
```

3. その他
servest.orgにてTypescriptファイルをホストしなくなったため、deno.landの方からimportするように変更しました。