### PR TITLE
ゲーム詳細でグラフのx,y軸を表示するように変更

### DIFF
--- a/pages/game/detail.tsx
+++ b/pages/game/detail.tsx
@@ -66,10 +66,8 @@ function PointsGraph(props: { game: Game }) {
       >
         <CartesianGrid strokeDasharray="3 3" />
 
-        {
-          /*<XAxis dataKey="turn" />
-        <YAxis />*/
-        }
+        <XAxis dataKey="turn" />
+        <YAxis />
         <Tooltip labelFormatter={(props) => "Turn : " + props} />
         <Legend />
 

--- a/pages/import-map.json
+++ b/pages/import-map.json
@@ -16,7 +16,7 @@
     "https://cdn.esm.sh/v41/@firebase/app@0.6.20/deno/app.js": "https://cdn.esm.sh/v41/firebase@8.5.0/deno/firebase.bundle.js",
     "https://cdn.esm.sh/v41/react-is@16.13.1/": "https://cdn.esm.sh/v41/react-is@17.0.2/",
     "https://cdn.esm.sh/v41/react-is@16.10.2/": "https://cdn.esm.sh/v41/react-is@17.0.2/",
-    "recharts": "https://cdn.esm.sh/recharts@1.8.4",
+    "recharts": "https://cdn.esm.sh/recharts@1.8.5",
     "react-firebaseui/": "https://esm.sh/react-firebaseui/",
     "https://cdn.esm.sh/v41/@popperjs/core@2.9.2/deno/core.js": "https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/cjs/popper.min.js",
     "https://cdn.esm.sh/v41/@popperjs/core@2.9.2/dist/cjs/popper.d.ts": "https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/lib/index.d.ts"

--- a/pages/import-map.json
+++ b/pages/import-map.json
@@ -16,7 +16,7 @@
     "https://cdn.esm.sh/v41/@firebase/app@0.6.20/deno/app.js": "https://cdn.esm.sh/v41/firebase@8.5.0/deno/firebase.bundle.js",
     "https://cdn.esm.sh/v41/react-is@16.13.1/": "https://cdn.esm.sh/v41/react-is@17.0.2/",
     "https://cdn.esm.sh/v41/react-is@16.10.2/": "https://cdn.esm.sh/v41/react-is@17.0.2/",
-    "recharts": "https://cdn.esm.sh/recharts@2.0.9",
+    "recharts": "https://cdn.esm.sh/recharts@1.8.4",
     "react-firebaseui/": "https://esm.sh/react-firebaseui/",
     "https://cdn.esm.sh/v41/@popperjs/core@2.9.2/deno/core.js": "https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/cjs/popper.min.js",
     "https://cdn.esm.sh/v41/@popperjs/core@2.9.2/dist/cjs/popper.d.ts": "https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/lib/index.d.ts"


### PR DESCRIPTION
XAxisとYAxisが上手く表示されなかったのでrechartsのバージョンを2.0.9=>1.8.4に落としました。