### PR TITLE
Game APIにて返される tilePoint、areaPointを削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ apiserver/data/
 *.code-workspace
 .idea/
 public/app.bundle.js
+
+.actrc

--- a/Kakomimasu.js
+++ b/Kakomimasu.js
@@ -721,10 +721,7 @@ class Game {
       const player = {
         id: id,
         agents: agents,
-        // don't need point, need tile&areaPoint
         point: this.field.getPoints()[i],
-        tilePoint: null,
-        areaPoint: null,
       };
       players.push(player);
     });

--- a/apiserver/test/sample/afterAction_sample.json
+++ b/apiserver/test/sample/afterAction_sample.json
@@ -1,5 +1,5 @@
 {
-  "gameId": "0d6243ab-96cd-41a8-9c48-35ac947703b0",
+  "gameId": "0e135484-f3ba-47a0-8655-d74bd7abb2bf",
   "gaming": true,
   "ending": false,
   "board": {
@@ -519,7 +519,7 @@
   ],
   "players": [
     {
-      "id": "ad868b26-2eea-4c6f-873a-b3693c9d0c66",
+      "id": "983177e0-beb9-4d19-8a75-3ac23cf5b5d7",
       "agents": [
         {
           "x": 1,
@@ -557,12 +557,10 @@
       "point": {
         "basepoint": 0,
         "wallpoint": 5
-      },
-      "tilePoint": null,
-      "areaPoint": null
+      }
     },
     {
-      "id": "ad868b26-2eea-4c6f-873a-b3693c9d0c66",
+      "id": "983177e0-beb9-4d19-8a75-3ac23cf5b5d7",
       "agents": [
         {
           "x": -1,
@@ -600,9 +598,7 @@
       "point": {
         "basepoint": 0,
         "wallpoint": 0
-      },
-      "tilePoint": null,
-      "areaPoint": null
+      }
     }
   ],
   "log": [
@@ -632,8 +628,8 @@
     ]
   ],
   "gameName": "test",
-  "startedAtUnixTime": 1618319170,
-  "nextTurnUnixTime": 1618319172,
+  "startedAtUnixTime": 1623071465,
+  "nextTurnUnixTime": 1623071467,
   "reservedUsers": [],
   "type": "self"
 }

--- a/apiserver/test/sample/matchGameInfo_sample.json
+++ b/apiserver/test/sample/matchGameInfo_sample.json
@@ -1,5 +1,5 @@
 {
-  "gameId": "0d6243ab-96cd-41a8-9c48-35ac947703b0",
+  "gameId": "0e135484-f3ba-47a0-8655-d74bd7abb2bf",
   "gaming": false,
   "ending": false,
   "board": {
@@ -519,7 +519,7 @@
   ],
   "players": [
     {
-      "id": "ad868b26-2eea-4c6f-873a-b3693c9d0c66",
+      "id": "983177e0-beb9-4d19-8a75-3ac23cf5b5d7",
       "agents": [
         {
           "x": -1,
@@ -557,12 +557,10 @@
       "point": {
         "basepoint": 0,
         "wallpoint": 0
-      },
-      "tilePoint": null,
-      "areaPoint": null
+      }
     },
     {
-      "id": "ad868b26-2eea-4c6f-873a-b3693c9d0c66",
+      "id": "983177e0-beb9-4d19-8a75-3ac23cf5b5d7",
       "agents": [
         {
           "x": -1,
@@ -600,15 +598,13 @@
       "point": {
         "basepoint": 0,
         "wallpoint": 0
-      },
-      "tilePoint": null,
-      "areaPoint": null
+      }
     }
   ],
   "log": [],
   "gameName": "test",
-  "startedAtUnixTime": 1618319170,
-  "nextTurnUnixTime": 1618319171,
+  "startedAtUnixTime": 1623071465,
+  "nextTurnUnixTime": 1623071466,
   "reservedUsers": [],
   "type": "self"
 }


### PR DESCRIPTION
もともとnullにしていて必要なかったものを削除
`point.basepoint`,`point.wallpoint`のようなもので代替可能

v1.0.0 Roadmap(#161 )