### PR TITLE
ビューアのゲーム詳細で1プレイヤーのみ参加した場合にエラーが出る問題を解決

### DIFF
--- a/Kakomimasu.js
+++ b/Kakomimasu.js
@@ -707,7 +707,7 @@ class Game {
     const players = [];
     this.players.forEach((p, i) => {
       const id = p.id;
-      let agents = null;
+      let agents = [];
       if (this.isReady()) {
         agents = [];
         this.agents[i].forEach((a) => {


### PR DESCRIPTION
ゲーム開始前に`game.players[i].agents`がnullになっていたことが原因
nullである必要はないため、空配列に変更しました。