### PR TITLE
Deno testの方式を変更しました

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,8 @@ jobs:
       - name: Run lint
         run: |
           deno lint --ignore=./act
-  deno_test:
-    runs-on: ubuntu-latest
-    name: Deno test by Docker
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Deno test
-        uses: ./ 
-  
-            
+      - name: Run test
+        run: |
+          deno cache ./apiserver/apiserver.ts
+          deno run -A ./apiserver/apiserver.ts --noViewer > /dev/null &
+          deno test -A

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM hayd/deno:latest
-
-COPY . .
-
-ENTRYPOINT ["/entrypoint.sh"]
-#CMD ["deno","cache", "./apiserver/apiserver.ts"]
-#CMD ["nohup", "deno", "run", "-A", "./apiserver/apiserver.ts" ,"&"]
-#CMD deno test -A

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,0 @@
-# action.yml
-name: 'Deno test'
-description: 'Deno test by Docker'
-runs:
-  using: 'docker'
-  image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh -l
-
-deno -V
-deno cache ./apiserver/apiserver.ts
-deno run -A ./apiserver/apiserver.ts --noViewer &
-deno run -A ./apiserver/parts/wait-start.ts
-deno test -A


### PR DESCRIPTION
今までは、Github Actions内にてDockerを起動し、その中でサーバを立てテストを行っていましたが、Dockerを起動しなくてもtest可能なことが分かったため変更しました。