### PR TITLE
ビューアのゲーム詳細でボードのx,yの数字が想定と異なるバグを修正

### DIFF
--- a/components/gameBoard.tsx
+++ b/components/gameBoard.tsx
@@ -275,7 +275,7 @@ export default function (props: Props) {
           {[...Array(game.board.height)].map((_, y) => {
             return (
               <tr>
-                <th>{y}</th>
+                <th>{y + 1}</th>
                 {[...Array(game.board.width)].map((_, x) => {
                   const cell = getCell(x, y);
                   const agent = isAgent(x, y);


### PR DESCRIPTION
Fixes #194 

![image](https://user-images.githubusercontent.com/47011206/123499800-2fb6ed80-d674-11eb-8c08-cff2a38f437b.png)
