### PR TITLE
deno fmtがうまく実行されていない問題を修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           deno-version: v1.x
       - name: Run fmt
         run: |
-          deno fmt --ignore=./act
+          deno fmt --check --ignore=./act
       - name: Run lint
         run: |
           deno lint --ignore=./act


### PR DESCRIPTION
--checkオプションがないと、ファイルを勝手にフォーマットしてくれる（Github actions内のみのファイルででリポジトリには影響ない）が、フォーマットされていないときにエラーを吐くわけではないため変更した。