### PR TITLE
”denoPlugin”のインポート元を変更

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,1 +1,2 @@
 -P ubuntu-latest=catthehacker/ubuntu:act-latest
+-j test

--- a/.actrc
+++ b/.actrc
@@ -1,2 +1,1 @@
 -P ubuntu-latest=catthehacker/ubuntu:act-latest
--j test

--- a/apiserver/deps.ts
+++ b/apiserver/deps.ts
@@ -12,5 +12,4 @@ export * from "https://deno.land/x/dotenv@v2.0.0/mod.ts";
 export * from "https://deno.land/x/servest@v1.3.1/mod.ts";
 export * from "https://deno.land/x/djwt@v2.2/mod.ts";
 export * as esbuild from "https://deno.land/x/esbuild@v0.11.17/mod.js";
-
-export { denoPlugin } from "https://raw.githubusercontent.com/lucacasonato/esbuild_deno_loader/fa2219c3df9494da6c33e3e4dffb1a33b5cc0345/mod.ts";
+export { denoPlugin } from "https://deno.land/x/esbuild_deno_loader@0.1.1/mod.ts";

--- a/apiserver/deps.ts
+++ b/apiserver/deps.ts
@@ -12,4 +12,5 @@ export * from "https://deno.land/x/dotenv@v2.0.0/mod.ts";
 export * from "https://deno.land/x/servest@v1.3.1/mod.ts";
 export * from "https://deno.land/x/djwt@v2.2/mod.ts";
 export * as esbuild from "https://deno.land/x/esbuild@v0.11.17/mod.js";
-export { denoPlugin } from "https://deno.land/x/esbuild_deno_loader@0.1.1/mod.ts";
+
+export { denoPlugin } from "https://raw.githubusercontent.com/lucacasonato/esbuild_deno_loader/fa2219c3df9494da6c33e3e4dffb1a33b5cc0345/mod.ts";


### PR DESCRIPTION
deno.land/xにて公開されていたのでそこからインポートするように変更しました。