### PR TITLE
Github Actionsの不要なコードを削除

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,1 +1,2 @@
 -P ubuntu-latest=catthehacker/ubuntu:act-latest
+-j test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,5 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ !env.ACT }}
-        run: echo "${{ secrets.SSH_PRIVATE_KEY }}" > secret_key && chmod 600 secret_key
-      - if: ${{ !env.ACT }}
-        run: ssh -oStrictHostKeyChecking=no root@practice.kakomimasu.website -i secret_key "cd ~/Kakomimasu && git pull && systemctl restart kakomimasu"
+      - run: echo "${{ secrets.SSH_PRIVATE_KEY }}" > secret_key && chmod 600 secret_key
+      - run: ssh -oStrictHostKeyChecking=no root@practice.kakomimasu.website -i secret_key "cd ~/Kakomimasu && git pull && systemctl restart kakomimasu"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# This workflow will install Deno and run tests across stable and nightly builds on Windows, Ubuntu and macOS.
-# For more information see: https://github.com/denolib/setup-deno
-
-
 on: [push]
 
 jobs:
@@ -19,10 +10,10 @@ jobs:
           deno-version: v1.x
       - name: Run fmt
         run: |
-          deno fmt --check --ignore=./act
+          deno fmt --check
       - name: Run lint
         run: |
-          deno lint --ignore=./act
+          deno lint
       - name: Run test
         run: |
           deno cache ./apiserver/apiserver.ts


### PR DESCRIPTION
Github Actionsのローカル実行ツール「act」で実行しやすいように
deploy.yml内にactで実行した際に実行しないように設定していましたが、
標準でtestジョブのみ実行するように変更したため、該当コードを削除しました。

もしactにてdeployを実行するときは、
```
$ act -j deploy
```
としてください。