### PR TITLE
ゲーム詳細でエージェント詳細がはみ出て見れないことがある

### DIFF
--- a/components/gameBoard.tsx
+++ b/components/gameBoard.tsx
@@ -81,7 +81,6 @@ const useStyles = makeStyles({
     left: "50%",
     textAlign: "center",
     borderRadius: "10px",
-    transform: "translate(+0%, -100%)",
     padding: "1em",
     filter: "drop-shadow(0 0 5px rgba(0, 0, 0, .7))",
     width: "max-content",
@@ -237,6 +236,15 @@ export default function (props: Props) {
     console.log("update gameBoard", game.tiled[0]);
   });*/
 
+  const getAgentTransform = (x: number, y: number) => {
+    if (!game.board) return;
+    const w = game.board.width;
+    const h = game.board.height;
+    const transX = x < w / 2 ? "0%" : "-100%";
+    const transY = y < h / 2 ? "0%" : "-100%";
+    return `translate(${transX},${transY})`;
+  };
+
   return (
     <div
       className={classes.content}
@@ -367,6 +375,7 @@ export default function (props: Props) {
                         className={classes.detail}
                         style={{
                           border: `solid 4px ${datas[agent.player].colors[1]}`,
+                          transform: getAgentTransform(x, y),
                         }}
                       >
                         <span>


### PR DESCRIPTION
Fixes #225

ボードからはみ出ないようにボードの内側方向に詳細を表示するように変更しました。
![image](https://user-images.githubusercontent.com/47011206/124601902-50b4e500-dea3-11eb-83e9-3e7cc60fbf68.png)
