### PR TITLE
ゲーム詳細の修正

### DIFF
--- a/components/gameBoard.tsx
+++ b/components/gameBoard.tsx
@@ -403,7 +403,7 @@ export default function (props: Props) {
                       </div>}
                   </td>;
                 })}
-                <th>{y}</th>
+                <th>{y + 1}</th>
               </tr>
             );
           })}

--- a/components/gamelist.tsx
+++ b/components/gamelist.tsx
@@ -167,7 +167,7 @@ const GameList = (props: {
                 >
                   <TableCell align="center">
                     <div className={getStatusClass(game)}>●</div>
-                    <div>{game.turn}</div>
+                    <div>{game.turn}/{game.totalTurn}</div>
                   </TableCell>
                   <TableCell>
                     <div className={classes.player}>

--- a/pages/game/detail.tsx
+++ b/pages/game/detail.tsx
@@ -64,10 +64,10 @@ function PointsGraph(props: { game: Game }) {
 
         <XAxis
           dataKey="turn"
-          domain={[0, game.totalTurn]}
+          domain={[0, game.totalTurn - 1]}
           tickFormatter={(turn: number) => turn + 1}
-          //type="number"
-          interval={0}
+          type="number"
+          tickCount={game.totalTurn / 2}
         />
         <YAxis />
         <Tooltip labelFormatter={(props: number) => "Turn : " + (props + 1)} />

--- a/pages/game/detail.tsx
+++ b/pages/game/detail.tsx
@@ -59,7 +59,6 @@ function PointsGraph(props: { game: Game }) {
         data={data}
         margin={{ top: 5, right: 10, left: 5, bottom: 5 }}
       >
-        >
         <CartesianGrid strokeDasharray="3 3" />
 
         <XAxis

--- a/pages/game/detail.tsx
+++ b/pages/game/detail.tsx
@@ -64,7 +64,7 @@ function PointsGraph(props: { game: Game }) {
         <XAxis
           dataKey="turn"
           domain={[0, game.totalTurn - 1]}
-          tickFormatter={(turn: string) => String(parseInt(turn) + 1)}
+          tickFormatter={(turn: number) => String(turn + 1)}
           type="number"
           tickCount={game.totalTurn / 2}
         />

--- a/pages/game/detail.tsx
+++ b/pages/game/detail.tsx
@@ -64,7 +64,7 @@ function PointsGraph(props: { game: Game }) {
         <XAxis
           dataKey="turn"
           domain={[0, game.totalTurn - 1]}
-          tickFormatter={(turn: number) => turn + 1}
+          tickFormatter={(turn: string) => String(parseInt(turn) + 1)}
           type="number"
           tickCount={game.totalTurn / 2}
         />

--- a/pages/game/detail.tsx
+++ b/pages/game/detail.tsx
@@ -57,12 +57,20 @@ function PointsGraph(props: { game: Game }) {
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
+        margin={{ top: 5, right: 10, left: 5, bottom: 5 }}
       >
+        >
         <CartesianGrid strokeDasharray="3 3" />
 
-        <XAxis dataKey="turn" />
+        <XAxis
+          dataKey="turn"
+          domain={[0, game.totalTurn]}
+          tickFormatter={(turn: number) => turn + 1}
+          //type="number"
+          interval={0}
+        />
         <YAxis />
-        <Tooltip labelFormatter={(props: string) => "Turn : " + props} />
+        <Tooltip labelFormatter={(props: number) => "Turn : " + (props + 1)} />
         <Legend />
 
         {game.players.map((_, i) => {


### PR DESCRIPTION
ゲーム総ターンを表示するように（ゲームリストの所に「現在ターン/総ターン」と表示されるように）
ゲームボードのy軸値のバグ
ゲーム詳細のグラフのターンを1開始に変更
ゲーム詳細のグラフを常に全ターン分表示するように