### PR TITLE
ビューア用のJSバンドルを非同期化しました

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,5 @@ jobs:
           deno cache --import-map ./pages/import-map.json --config ./pages/tsconfig.json ./pages/route.tsx
       - name: Run test
         run: |
-          deno run -A ./apiserver/apiserver.ts --noViewer > /dev/null &
+          deno run -A ./apiserver/apiserver.ts > /dev/null &
           deno test -A

--- a/apiserver/deps.ts
+++ b/apiserver/deps.ts
@@ -1,6 +1,5 @@
 // Standard Library
 export { fromFileUrl } from "https://deno.land/std@0.101.0/path/mod.ts";
-export { parse } from "https://deno.land/std@0.101.0/flags/mod.ts";
 export {
   assert,
   assertEquals,

--- a/apiserver/viewer.ts
+++ b/apiserver/viewer.ts
@@ -1,16 +1,9 @@
-import {
-  createRouter,
-  denoPlugin,
-  esbuild,
-  parse,
-  serveStatic,
-} from "./deps.ts";
-const args = parse(Deno.args);
+import { createRouter, denoPlugin, esbuild, serveStatic } from "./deps.ts";
 
 import * as util from "./apiserver_util.ts";
 const resolve = util.pathResolver(import.meta);
 
-if (!args.noViewer) {
+async function createBundleJsFile() {
   const _bundle = await esbuild.build({
     entryPoints: ["file:///" + resolve("../pages/route.tsx")],
     plugins: [
@@ -20,7 +13,9 @@ if (!args.noViewer) {
     outfile: resolve("../public/app.bundle.js"),
     minify: true,
   });
+  console.log("Viewer started.");
 }
+createBundleJsFile();
 
 export const viewerRoutes = () => {
   const router = createRouter();


### PR DESCRIPTION
サーバを起動したときにビューア用のJSバンドルを非同期化することで、先にAPIサーバを起動完了しました。

この変更により、Github Actionsのtestに--noViewerオプションを入れなくてもよくなったのでtest.ymlも変更しました。