### PR TITLE
nextTurnUnixTimeの算出方法を変更

### DIFF
--- a/apiserver/parts/expKakomimasu.ts
+++ b/apiserver/parts/expKakomimasu.ts
@@ -134,6 +134,14 @@ class ExpGame extends Game {
     }
   }
 
+  getNextTurnUnixTime() {
+    if (this.startedAtUnixTime === null || this.ending) {
+      return null;
+    } else {
+      return this.startedAtUnixTime + this.nsec * this.turn;
+    }
+  }
+
   toJSON(): GameType {
     const ret = super.toJSON();
     return {
@@ -141,7 +149,7 @@ class ExpGame extends Game {
       gameId: this.uuid,
       gameName: this.name,
       startedAtUnixTime: this.startedAtUnixTime,
-      nextTurnUnixTime: this.nextTurnUnixTime,
+      nextTurnUnixTime: this.getNextTurnUnixTime(),
       reservedUsers: this.reservedUsers,
       type: this.type,
     };

--- a/apiserver/test/flow_test.ts
+++ b/apiserver/test/flow_test.ts
@@ -130,7 +130,7 @@ Deno.test("send action(Turn 1)", async () => {
   if (res.success === false) {
     throw Error("Response Error. ErrorCode:" + res.data.errorCode);
   }
-  const gameInfo = res.data;
+  let gameInfo = res.data;
   if (!gameInfo.startedAtUnixTime) throw Error("startedAtUnixTime is null.");
   await sleep(diffTime(gameInfo.startedAtUnixTime) + 100);
   await ac.setAction(gameId, {
@@ -138,6 +138,12 @@ Deno.test("send action(Turn 1)", async () => {
     index: 0,
   }, "Bearer " + bearerToken);
   //console.log(reqJson);
+
+  res = await ac.getMatch(gameId);
+  if (res.success === false) {
+    throw Error("Response Error. ErrorCode:" + res.data.errorCode);
+  }
+  gameInfo = res.data;
 
   if (!gameInfo.nextTurnUnixTime) throw Error("nextTurnUnixTime is null.");
   await sleep(diffTime(gameInfo.nextTurnUnixTime) + 100);
@@ -157,8 +163,8 @@ Deno.test("send action(Turn 1)", async () => {
   sample.gameId = res.data.gameId = "";
   sample.players[0].id = res.data.players[0].id = "";
   sample.players[1].id = res.data.players[1].id = "";
-  sample.startedAtUnixTime = res.data.startedAtUnixTime = 0;
-  sample.nextTurnUnixTime = res.data.nextTurnUnixTime = 0;
+  sample.startedAtUnixTime = res.data.startedAtUnixTime;
+  sample.nextTurnUnixTime = res.data.nextTurnUnixTime;
 
   assertEquals(sample, res.data);
 });
@@ -195,8 +201,8 @@ Deno.test("send action(Turn 2)", async () => {
   sample.gameId = res.data.gameId = "";
   sample.players[0].id = res.data.players[0].id = "";
   sample.players[1].id = res.data.players[1].id = "";
-  sample.startedAtUnixTime = res.data.startedAtUnixTime = 0;
-  sample.nextTurnUnixTime = res.data.nextTurnUnixTime = 0;
+  sample.startedAtUnixTime = res.data.startedAtUnixTime;
+  sample.nextTurnUnixTime = res.data.nextTurnUnixTime;
 
   assertEquals(sample, res.data);
 });


### PR DESCRIPTION
現在の`nextTurnUnixTime`に`nsec`を足していく方式から、
`startedAtUnixTime`と`turn`から`nextTurnUnixTime`を計算する方法に変更しました。

これに従い、試合開始前の`startedAtUnixTime`と`nextTurnUnixTime`がどちらも1ターン目の開始時間を示すようになりました。（以前は`nextTurnUnixTime`は2ターン目の開始時間を示していた）