### PR TITLE
認証失敗時の`WWW-Authenticate`ヘッダに`realm`を追加

### DIFF
--- a/apiserver/docs/users_api.md
+++ b/apiserver/docs/users_api.md
@@ -74,6 +74,10 @@ GET /api/users/show/(ユーザのname又はID)
 POST /api/users/delete
 ```
 
+### Authorizationヘッダ
+
+HTTPリクエストのヘッダにBearer認証を含める必要があります。
+
 ### パラメータJSON
 
 以下のパラメータを含んだJSONをbodyに入れて送信して下さい。

--- a/apiserver/middleware.ts
+++ b/apiserver/middleware.ts
@@ -56,13 +56,13 @@ export const auth = (
 
       //const headers = resTemp.headers
       if (basic) {
-        headers.append("WWW-Authenticate", "Basic");
+        headers.append("WWW-Authenticate", `Basic realm="token_required"`);
       }
       if (bearer) {
-        headers.append("WWW-Authenticate", "Bearer");
+        headers.append("WWW-Authenticate", `Bearer realm="token_required"`);
       }
       if (jwt) {
-        headers.append("WWW-Authenticate", "JWT");
+        headers.append("WWW-Authenticate", `JWT realm="token_required"`);
       }
       req.respond({ status: 401, headers, body });
     }

--- a/apiserver/test/auth_test.ts
+++ b/apiserver/test/auth_test.ts
@@ -1,9 +1,5 @@
-import { assert, assertEquals } from "../deps.ts";
-import { errors } from "../error.ts";
+import { assert } from "../deps.ts";
 import { randomUUID } from "../apiserver_util.ts";
-
-import ApiClient from "../../client_js/api_client.js";
-const ac = new ApiClient();
 
 const authRequiredUrlList = [
   `match`,
@@ -25,8 +21,6 @@ authRequiredUrlList.forEach((url) => {
     const wwwAuthentiate = res.headers.get("WWW-Authenticate");
     assert(wwwAuthentiate !== null);
     assert(wwwAuthentiate.includes(`Bearer realm="token_required`));
-    const body = await res.json();
-    //console.log(body);
-    //assertEquals(body, errors.INVALID_CONTENT_TYPE);
+    await res.text();
   });
 });

--- a/apiserver/test/auth_test.ts
+++ b/apiserver/test/auth_test.ts
@@ -1,0 +1,32 @@
+import { assert, assertEquals } from "../deps.ts";
+import { errors } from "../error.ts";
+import { randomUUID } from "../apiserver_util.ts";
+
+import ApiClient from "../../client_js/api_client.js";
+const ac = new ApiClient();
+
+const authRequiredUrlList = [
+  `match`,
+  `match/${randomUUID()}/action`,
+  `users/delete`,
+];
+
+// fetch all urls by no Authorization header
+authRequiredUrlList.forEach((url) => {
+  Deno.test(`${url} nothing Authorization header`, async () => {
+    const res = await fetch("http://localhost:8880/api/" + url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    console.log(res.headers);
+    const wwwAuthentiate = res.headers.get("WWW-Authenticate");
+    assert(wwwAuthentiate !== null);
+    assert(wwwAuthentiate.includes(`Bearer realm="token_required`));
+    const body = await res.json();
+    //console.log(body);
+    //assertEquals(body, errors.INVALID_CONTENT_TYPE);
+  });
+});


### PR DESCRIPTION
Fixes #193